### PR TITLE
Include opencv2/imgproc.hpp for CV_RGB()

### DIFF
--- a/src/filter/facebl0r/facebl0r.cpp
+++ b/src/filter/facebl0r/facebl0r.cpp
@@ -15,11 +15,17 @@
  */
 
 
+#include <opencv2/core/version.hpp>
+#define CV_VERSION_NUM (CV_VERSION_MAJOR * 10000 \
+                      + CV_VERSION_MINOR * 100 \
+                      + CV_VERSION_REVISION)
 #include <stdio.h>
 #include <stdlib.h>
 #include <opencv/cv.h>
 #include <opencv/highgui.h>
+#if CV_VERSION_NUM > 30401
 #include <opencv2/imgproc.hpp>
+#endif
 
 #include <frei0r.hpp>
 #include <frei0r_math.h>

--- a/src/filter/facebl0r/facebl0r.cpp
+++ b/src/filter/facebl0r/facebl0r.cpp
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <opencv/cv.h>
 #include <opencv/highgui.h>
+#include <opencv2/imgproc.hpp>
 
 #include <frei0r.hpp>
 #include <frei0r_math.h>


### PR DESCRIPTION
Signed-off-by: Christoph Willing <chris.willing@linux.com>

This addresses issue #26 