### PR TITLE
build and memory fix

### DIFF
--- a/src/filter/bgsubtract0r/bgsubtract0r.c
+++ b/src/filter/bgsubtract0r/bgsubtract0r.c
@@ -72,7 +72,7 @@ void f0r_get_plugin_info(f0r_plugin_info_t* bgsubtract0r_info)
   bgsubtract0r_info->color_model = F0R_COLOR_MODEL_RGBA8888;
   bgsubtract0r_info->frei0r_version = FREI0R_MAJOR_VERSION;
   bgsubtract0r_info->major_version = 0;
-  bgsubtract0r_info->minor_version = 2;
+  bgsubtract0r_info->minor_version = 3;
   bgsubtract0r_info->num_params =  3;
   bgsubtract0r_info->explanation = "Bluescreen the background of a static video.";
 }
@@ -86,7 +86,7 @@ f0r_instance_t f0r_construct(unsigned int width, unsigned int height)
   inst->blur = 0;
   inst->threshold = 26;
   inst->reference = NULL;
-  inst->mask = malloc(width*height);
+  inst->mask = malloc(sizeof(uint32_t)*width*height);
   return (f0r_instance_t)inst;
 }
 

--- a/src/filter/facebl0r/facebl0r.cpp
+++ b/src/filter/facebl0r/facebl0r.cpp
@@ -16,8 +16,8 @@
 
 
 #include <opencv2/core/version.hpp>
-#define CV_VERSION_NUM (CV_VERSION_MAJOR * 10000 \
-                      + CV_VERSION_MINOR * 100 \
+#define CV_VERSION_NUM (CV_MAJOR_VERSION * 10000 \
+                      + CV_MINOR_VERSION * 100 \
                       + CV_VERSION_REVISION)
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
*  facebl0r : fix build 
version check was giving wrong result.

* bgsubstract0r : fix memory allocation
data type was missing (buffer overflow)