### PR TITLE
silence some sign-compare warnings

### DIFF
--- a/src/filter/d90stairsteppingfix/d90stairsteppingfix.cpp
+++ b/src/filter/d90stairsteppingfix/d90stairsteppingfix.cpp
@@ -164,7 +164,7 @@ public:
             
             float scaleFactor = (float) newHeight/height;
 //          printf("scale factor: %f\n", scaleFactor);
-            for (int i = 0; i < height; i++) {
+            for (unsigned int i = 0; i < height; i++) {
                 downScaling[i] = (float) (((2*i+1)*scaleFactor)-1)/2;
 //              printf("scaled: %f at %d\n", downScaling[i], i);
             }
@@ -176,7 +176,7 @@ public:
              * calculated scaling numbers.
              */
             float offset;
-            for (int i = 0; i < height; i++) {
+            for (unsigned int i = 0; i < height; i++) {
                 
                 index = floor(downScaling[i]);
                 offset = downScaling[i] - index;
@@ -208,7 +208,7 @@ public:
             unsigned char *cvA, *cvB, *cvOut;
             
             
-            for (int line = 0; line < height; line++) {
+            for (unsigned int line = 0; line < height; line++) {
                 index = floor(m_mesh[line]);
                 factor = (float) m_mesh[line] - index;
                 
@@ -216,7 +216,7 @@ public:
                 cvB = (unsigned char*) &in[width*(index+1)];
                 cvOut = (unsigned char*) &out[width*line];
                     
-                for (int pixel = 0; pixel < width*4; pixel++) {
+                for (unsigned int pixel = 0; pixel < width*4; pixel++) {
                     // Use linear interpolation on the colours
                     
                     // Use pointer arithmetics. Colour values are stored 

--- a/src/filter/ndvi/gradientlut.hpp
+++ b/src/filter/ndvi/gradientlut.hpp
@@ -61,7 +61,7 @@ void GradientLut::fillRange( double startPos, const GradientLut::Color& startCol
 
     if(span < 1) span = 1;
 
-    for(int i = 0; i <= span; i++) {
+    for(unsigned int i = 0; i <= span; i++) {
         Color color;
         double ratio = (double)i / (double)span;
 

--- a/src/filter/ndvi/ndvi.cpp
+++ b/src/filter/ndvi/ndvi.cpp
@@ -129,7 +129,7 @@ void Ndvi::update(double time,
     initLut();
 
     if (paramIndex == "vi") {
-        for (int i = 0; i < size; i++) {
+        for (unsigned int i = 0; i < size; i++) {
             double vis =  getComponent(inP, visChan, visOffset, visScale);
             double nir =  getComponent(inP, nirChan, nirOffset, nirScale);
             double vi = (nir - vis) / 255.0;
@@ -138,7 +138,7 @@ void Ndvi::update(double time,
             outP += 4;
         }
     } else { // ndvi
-        for (int i = 0; i < size; i++) {
+        for (unsigned int i = 0; i < size; i++) {
             double vis =  getComponent(inP, visChan, visOffset, visScale);
             double nir =  getComponent(inP, nirChan, nirOffset, nirScale);
             double ndvi = (nir - vis) / (nir + vis);

--- a/src/filter/primaries/primaries.cpp
+++ b/src/filter/primaries/primaries.cpp
@@ -56,7 +56,7 @@ public:
 			factorTot = 3;
 		}
 		
-		for (int i = 0; i < size; i++) {
+		for (unsigned int i = 0; i < size; i++) {
 			px_t pi;
 			pi.u = in[i];
 			

--- a/src/filter/tutorial/tutorial.cpp
+++ b/src/filter/tutorial/tutorial.cpp
@@ -64,7 +64,7 @@ public:
         // We'll use a calculation that looks expensive here.
         float f, h;
         int tempVal;
-        for (int i = 0; i < lookupTable.size(); i++) {
+        for (size_t i = 0; i < lookupTable.size(); i++) {
             f = i / (float)std::numeric_limits<uint8_t>::max(); // Normalize to [0,1]
             h = f/5;
             f = 2*f - 1; // Stretch to [-1,1]
@@ -129,8 +129,8 @@ public:
         if (m_pointerMethod == 0) {
             uint8_t *in_pointer = (uint8_t *) in;
             uint8_t *out_pointer = (uint8_t *) out;
-            for (int x = 0; x < width; x++) {
-                for (int y = 0; y < height; y++) {
+            for (unsigned int x = 0; x < width; x++) {
+                for (unsigned int y = 0; y < height; y++) {
 
                     // Apply the parabola to the R channel with a single lookup
                     *out_pointer++ = lookupTable[*in_pointer++];
@@ -148,7 +148,7 @@ public:
             // This method takes only 80% of the time if only processing the R channel,
             // and 90% of the time with additionally the G channel,
             // compared to the above solution using uint8_t pointers.
-            for (int px = 0; px < width*height; px++) {
+            for (unsigned int px = 0; px < width*height; px++) {
                 out[px] =
                             // Parabola to Red channel
                             lookupTable[(in[px] & 0xFF)]

--- a/src/filter/vignette/vignette.cpp
+++ b/src/filter/vignette/vignette.cpp
@@ -87,7 +87,7 @@ public:
 
         // Darken the pixels by multiplying with the vignette's factor
         float *vignette = m_vignette;
-        for (int i = 0; i < size; i++) {
+        for (unsigned int i = 0; i < size; i++) {
             *dest++ = (char) (*vignette * *pixel++);
             *dest++ = (char) (*vignette * *pixel++);
             *dest++ = (char) (*vignette * *pixel++);

--- a/src/mixer2/alphaatop/alphaatop.cpp
+++ b/src/mixer2/alphaatop/alphaatop.cpp
@@ -38,7 +38,7 @@ public:
     const uint8_t *src1 = reinterpret_cast<const uint8_t*>(in1);
     const uint8_t *src2 = reinterpret_cast<const uint8_t*>(in2);
     
-    for (int i=0; i<size; ++i)
+    for (unsigned int i=0; i<size; ++i)
     {
       uint32_t tmp;
       uint8_t alpha_src1 = src1[3];

--- a/src/mixer2/alphain/alphain.cpp
+++ b/src/mixer2/alphain/alphain.cpp
@@ -38,7 +38,7 @@ public:
     const uint8_t *src1 = reinterpret_cast<const uint8_t*>(in1);
     const uint8_t *src2 = reinterpret_cast<const uint8_t*>(in2);
     
-    for (int i=0; i<size; ++i)
+    for (unsigned int i=0; i<size; ++i)
     {
       uint32_t tmp;
       uint8_t alpha_src1 = src1[3];

--- a/src/mixer2/alphaout/alphaout.cpp
+++ b/src/mixer2/alphaout/alphaout.cpp
@@ -38,7 +38,7 @@ public:
     const uint8_t *src1 = reinterpret_cast<const uint8_t*>(in1);
     const uint8_t *src2 = reinterpret_cast<const uint8_t*>(in2);
     
-    for (int i=0; i<size; ++i)
+    for (unsigned int i=0; i<size; ++i)
     {
       uint32_t tmp;
       uint8_t alpha_src1 = src1[3];

--- a/src/mixer2/alphaover/alphaover.cpp
+++ b/src/mixer2/alphaover/alphaover.cpp
@@ -38,7 +38,7 @@ public:
     const uint8_t *src1 = reinterpret_cast<const uint8_t*>(in1);
     const uint8_t *src2 = reinterpret_cast<const uint8_t*>(in2);
     
-    for (int i=0; i<size; ++i)
+    for (unsigned int i=0; i<size; ++i)
     {
       uint32_t tmp;
       uint8_t alpha_src1 = src1[3];

--- a/src/mixer2/alphaxor/alphaxor.cpp
+++ b/src/mixer2/alphaxor/alphaxor.cpp
@@ -38,7 +38,7 @@ public:
     const uint8_t *src1 = reinterpret_cast<const uint8_t*>(in1);
     const uint8_t *src2 = reinterpret_cast<const uint8_t*>(in2);
     
-    for (int i=0; i<size; ++i)
+    for (unsigned int i=0; i<size; ++i)
     {
       uint32_t tmp;
       uint8_t alpha_src1 = src1[3];


### PR DESCRIPTION
These are the trivial cases where the iterator variable type can be changed to unsigned.