### PR TITLE
CMakeLists: Don't hardcode pkgconfig install dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,9 +44,10 @@ add_subdirectory (doc)
 add_subdirectory (src)
 
 # Generate frei0r.pc and install it.
+include(GNUInstallDirs)
 set (prefix "${CMAKE_INSTALL_PREFIX}")
 set (exec_prefix "${CMAKE_INSTALL_PREFIX}")
 set (libdir "${CMAKE_INSTALL_PREFIX}/lib")
 set (includedir "${CMAKE_INSTALL_PREFIX}/include")
 configure_file ("frei0r.pc.in" "frei0r.pc" @ONLY)
-install (FILES "${CMAKE_CURRENT_BINARY_DIR}/frei0r.pc" DESTINATION lib/pkgconfig)
+install (FILES "${CMAKE_CURRENT_BINARY_DIR}/frei0r.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")


### PR DESCRIPTION
Currently the pkgconfig files are hardcoded to be installed to
`$CMAKE_INSTALL_PREFIX/lib/pkgconfig`, which affects installations that
are using a differente library directory. This patch allows the use of
the GNUInstallDirs package to modify the installation libdir at build
time and to install the pkgconfig files to
`$CMAKE_INSTALL_LIBDIR`/pkgconfig.

Addresses #79

A previous attempt was made in #80, which failed without the
GNUInstallDirs package being required.