### PR TITLE
Include GNUInstallDirs before using CMAKE_INSTALL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 2.8)
+include(GNUInstallDirs)
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
@@ -44,7 +45,6 @@ add_subdirectory (doc)
 add_subdirectory (src)
 
 # Generate frei0r.pc and install it.
-include(GNUInstallDirs)
 set (prefix "${CMAKE_INSTALL_PREFIX}")
 set (exec_prefix "${CMAKE_INSTALL_PREFIX}")
 set (libdir "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")


### PR DESCRIPTION
This fixes the install directories when  CMAKE_INSTALL_LIBDIR is not specified:
```
$ cmake .
$ make install
...
-- Installing: /usr/local/mylibdir/pkgconfig/frei0r.pc
-- Installing: /frei0r-1/facebl0r.so
-- Installing: /frei0r-1/facedetect.so
...
```
(Tested on OpenBSD)