### PR TITLE
scanline0r: Smoother scanline appearance

### DIFF
--- a/src/filter/scanline0r/scanline0r.cpp
+++ b/src/filter/scanline0r/scanline0r.cpp
@@ -2,6 +2,27 @@
 
 #include <algorithm>
 
+static inline uint8_t
+scale(uint8_t value, uint8_t factor)
+{
+  return std::min((uint16_t)((uint16_t)value * (uint16_t)factor / 128), (uint16_t)value);
+}
+
+static inline void
+scale_scanline(uint32_t *dst_begin, const uint32_t *src_begin, const uint32_t *src_end, uint8_t factor)
+{
+  union { uint32_t u32; uint8_t u8[4]; } v;
+
+  while (src_begin < src_end) {
+    v.u32 = *src_begin++;
+    v.u8[0] = scale(v.u8[0], factor);
+    v.u8[1] = scale(v.u8[1], factor);
+    v.u8[2] = scale(v.u8[2], factor);
+    v.u8[3] = scale(v.u8[3], factor);
+    *dst_begin++ = v.u32;
+  }
+}
+
 class scanline0r : public frei0r::filter
 {
 public:
@@ -14,10 +35,10 @@ public:
                       uint32_t* out,
                       const uint32_t* in)
   {
-    for (unsigned int line=0; line < height; line+=4)
+    for (unsigned int line=0; line < height; line+=2)
       {
-	std::copy(in+line*width,in+(line+1)*width,out+(line*width));
-	std::fill(out+(line+1)*width,out+(line+4)*width,0x00000000);
+        scale_scanline(out+line*width, in+line*width, in+(line+1)*width, 150);
+        scale_scanline(out+(line+1)*width, in+(line+1)*width, in+(line+2)*width, 64);
       }
   }
   

--- a/src/filter/scanline0r/scanline0r.cpp
+++ b/src/filter/scanline0r/scanline0r.cpp
@@ -48,7 +48,7 @@ private:
 
 
 frei0r::construct<scanline0r> plugin("scanline0r",
-				     "interlaced blak lines",
+				     "interlaced dark lines",
 				     "Martin Bayer",
-				     0,2);
+				     0,3);
 


### PR DESCRIPTION
Make the scanline effect be 1 lighter line, 1 darker line (no black lines), alternating. Brighten up the odd lines (and darken the even ones) so that the average brightness isn't affected too much (these values -- `150` and `64` might need tweaking).

The `scanline0r` filter can be used for displaying a live captured composite video signal in [Cheese](https://wiki.gnome.org/Apps/Cheese) in combination with the [GStreamer plugin](https://gstreamer.freedesktop.org/documentation/frei0r/) and the following file in `/usr/share/gnome-video-effects/scanlines.effect`:

```
[Effect]
Encoding=UTF-8
Name=Scanlines
Comment=Scanline filter from frei0r
PipelineDescription=frei0r-filter-scanline0r
```

Example effect, original image:

![no-scanlines](https://user-images.githubusercontent.com/135241/66722523-1540d000-ee0f-11e9-8ff6-576622b6f657.jpg)

With the patched `scanline0r` effect:

![with-scanlines](https://user-images.githubusercontent.com/135241/66722527-1ffb6500-ee0f-11e9-81ab-be3e7837dcf8.jpg)
