### PR TITLE
Speed up premultiply with 0 alpha

### DIFF
--- a/include/frei0r_cairo.h
+++ b/include/frei0r_cairo.h
@@ -234,7 +234,9 @@ void frei0r_cairo_premultiply_rgba (unsigned char *rgba, int pixels, int alpha)
   int i = pixels + 1;
   while ( --i ) {
     register unsigned char a = rgba[3];
-    if (a < 0xff) {
+    if (a == 0) {
+      *((uint32_t *)rgba) = 0;
+    } else if (a < 0xff) {
       rgba[0] = ( rgba[0] * a ) >> 8;
       rgba[1] = ( rgba[1] * a ) >> 8;
       rgba[2] = ( rgba[2] * a ) >> 8;


### PR DESCRIPTION
Skip the multiplications if the alpha channel is 0 to speed up cases
where the image is mostly fully transparent. perf showed this function
to be a hotspot when compositing a mostly transparent image onto a video
at 4K resolution.

Timings in ms with a (best-case) fully transparent 3840x2160 image:

        Before       After
-02     8.7          5.1
-03     8.7          4.1