### PR TITLE
autotools fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,9 @@
 # Copyright (C) 2007 Richard Spindler <richard.spindler AT gmail.com>
-#  
+#
 # This file is free software; as a special exception the author gives
-# unlimited permission to copy and/or distribute it, with or without 
+# unlimited permission to copy and/or distribute it, with or without
 # modifications, as long as this notice is preserved.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
@@ -16,4 +16,4 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = frei0r.pc
 
 docsdir = ${prefix}/share/doc/${PACKAGE}
-docs_DATA = README.md ChangeLog TODO AUTHORS 
+docs_DATA = README.md ChangeLog TODO AUTHORS

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,9 +1,9 @@
 # Copyright (C) 2007 Richard Spindler <richard.spindler AT gmail.com>
-#  
+#
 # This file is free software; as a special exception the author gives
-# unlimited permission to copy and/or distribute it, with or without 
+# unlimited permission to copy and/or distribute it, with or without
 # modifications, as long as this notice is preserved.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,9 +1,9 @@
 # Copyright (C) 2007 Richard Spindler <richard.spindler AT gmail.com>
-#  
+#
 # This file is free software; as a special exception the author gives
-# unlimited permission to copy and/or distribute it, with or without 
+# unlimited permission to copy and/or distribute it, with or without
 # modifications, as long as this notice is preserved.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -329,9 +329,9 @@ value_la_SOURCES = mixer2/value/value.cpp
 xfade0r_la_SOURCES = mixer2/xfade0r/xfade0r.cpp
 
 
-AM_CPPFLAGS = -I@top_srcdir@/include -Waddress -Wtype-limits -Wsign-compare
-AM_CFLAGS = -I@top_srcdir@/include -Waddress -Wtype-limits -Wsign-compare
-AM_CXXFLAGS = -I@top_srcdir@/include -Waddress -Wtype-limits -Wsign-compare
+AM_CPPFLAGS = -I@top_srcdir@/include
+AM_CFLAGS = -Waddress -Wtype-limits -Wsign-compare
+AM_CXXFLAGS = -Waddress -Wtype-limits -Wsign-compare
 AM_LDFLAGS = -module -avoid-version -lm -export-dynamic
 AM_LIBTOOLFLAGS = --tag=disable-static
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -156,11 +156,11 @@ endif
 if HAVE_OPENCV
 plugin_LTLIBRARIES += facebl0r.la
 facebl0r_la_SOURCES = filter/facebl0r/facebl0r.cpp
-facebl0r_la_CFLAGS = $(OPENCV_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
+facebl0r_la_CXXFLAGS = $(OPENCV_CFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
 facebl0r_la_LIBADD = $(OPENCV_LIBS)
 plugin_LTLIBRARIES += facedetect.la
 facedetect_la_SOURCES = filter/facedetect/facedetect.cpp
-facedetect_la_CFLAGS = $(OPENCV_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
+facedetect_la_CXXFLAGS = $(OPENCV_CFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
 facedetect_la_LIBADD = $(OPENCV_LIBS)
 endif
 
@@ -185,7 +185,7 @@ cairoblend_la_SOURCES = mixer2/cairoblend/cairoblend.c
 cairoblend_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
 cairoblend_la_LIBADD = $(CAIRO_LIBS)
 
-ndvi_la_CPPFLAGS = $(CAIRO_CFLAGS) $(CPPFLAGS) -DHAVE_CAIRO
+ndvi_la_CXXFLAGS = $(CAIRO_CFLAGS) $(CXXFLAGS) -DHAVE_CAIRO
 ndvi_la_LIBADD = $(CAIRO_LIBS)
 endif
 
@@ -331,6 +331,7 @@ xfade0r_la_SOURCES = mixer2/xfade0r/xfade0r.cpp
 
 AM_CPPFLAGS = -I@top_srcdir@/include -Waddress -Wtype-limits -Wsign-compare
 AM_CFLAGS = -I@top_srcdir@/include -Waddress -Wtype-limits -Wsign-compare
+AM_CXXFLAGS = -I@top_srcdir@/include -Waddress -Wtype-limits -Wsign-compare
 AM_LDFLAGS = -module -avoid-version -lm -export-dynamic
 AM_LIBTOOLFLAGS = --tag=disable-static
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,9 @@
 # Copyright (C) 2007 Richard Spindler <richard.spindler AT gmail.com>
-#  
+#
 # This file is free software; as a special exception the author gives
-# unlimited permission to copy and/or distribute it, with or without 
+# unlimited permission to copy and/or distribute it, with or without
 # modifications, as long as this notice is preserved.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,54 +139,54 @@ plugin_LTLIBRARIES = \
 if HAVE_GAVL
 plugin_LTLIBRARIES += scale0tilt.la
 scale0tilt_la_SOURCES = filter/scale0tilt/scale0tilt.c
-scale0tilt_la_CFLAGS = @GAVL_CFLAGS@ @CFLAGS@
-scale0tilt_la_LIBADD = @GAVL_LIBS@
+scale0tilt_la_CFLAGS = $(GAVL_CFLAGS) $(CFLAGS)
+scale0tilt_la_LIBADD = $(GAVL_LIBS)
 
 plugin_LTLIBRARIES += vectorscope.la
 vectorscope_la_SOURCES = filter/vectorscope/vectorscope.c filter/vectorscope/vectorscope_image.h
-vectorscope_la_CFLAGS = @GAVL_CFLAGS@ @CFLAGS@
-vectorscope_la_LIBADD = @GAVL_LIBS@
+vectorscope_la_CFLAGS = $(GAVL_CFLAGS) $(CFLAGS)
+vectorscope_la_LIBADD = $(GAVL_LIBS)
 
 plugin_LTLIBRARIES += rgbparade.la
 rgbparade_la_SOURCES = filter/rgbparade/rgbparade.c filter/rgbparade/rgbparade_image.h
-rgbparade_la_CFLAGS = @GAVL_CFLAGS@ @CFLAGS@
-rgbparade_la_LIBADD = @GAVL_LIBS@
+rgbparade_la_CFLAGS = $(GAVL_CFLAGS) $(CFLAGS)
+rgbparade_la_LIBADD = $(GAVL_LIBS)
 endif
 
 if HAVE_OPENCV
 plugin_LTLIBRARIES += facebl0r.la
 facebl0r_la_SOURCES = filter/facebl0r/facebl0r.cpp
-facebl0r_la_CFLAGS = @OPENCV_CFLAGS@ @CFLAGS@ 
-facebl0r_la_LIBADD = @OPENCV_LIBS@
+facebl0r_la_CFLAGS = $(OPENCV_CFLAGS) $(CFLAGS)
+facebl0r_la_LIBADD = $(OPENCV_LIBS)
 plugin_LTLIBRARIES += facedetect.la
 facedetect_la_SOURCES = filter/facedetect/facedetect.cpp
-facedetect_la_CFLAGS = @OPENCV_CFLAGS@ @CFLAGS@
-facedetect_la_LIBADD = @OPENCV_LIBS@
+facedetect_la_CFLAGS = $(OPENCV_CFLAGS) $(CFLAGS)
+facedetect_la_LIBADD = $(OPENCV_LIBS)
 endif
 
 if HAVE_CAIRO
 plugin_LTLIBRARIES += cairogradient.la
 cairogradient_la_SOURCES = filter/cairogradient/cairogradient.c
-cairogradient_la_CFLAGS = @CAIRO_CFLAGS@ @CFLAGS@
-cairogradient_la_LIBADD = @CAIRO_LIBS@
+cairogradient_la_CFLAGS = $(CAIRO_CFLAGS) $(CFLAGS)
+cairogradient_la_LIBADD = $(CAIRO_LIBS)
 
 plugin_LTLIBRARIES += cairoimagegrid.la
 cairoimagegrid_la_SOURCES = filter/cairoimagegrid/cairoimagegrid.c
-cairoimagegrid_la_CFLAGS = @CAIRO_CFLAGS@ @CFLAGS@
-cairoimagegrid_la_LIBADD = @CAIRO_LIBS@
+cairoimagegrid_la_CFLAGS = $(CAIRO_CFLAGS) $(CFLAGS)
+cairoimagegrid_la_LIBADD = $(CAIRO_LIBS)
 
 plugin_LTLIBRARIES += cairoaffineblend.la
 cairoaffineblend_la_SOURCES = mixer2/cairoaffineblend/cairoaffineblend.c
-cairoaffineblend_la_CFLAGS = @CAIRO_CFLAGS@ @CFLAGS@
-cairoaffineblend_la_LIBADD = @CAIRO_LIBS@
+cairoaffineblend_la_CFLAGS = $(CAIRO_CFLAGS) $(CFLAGS)
+cairoaffineblend_la_LIBADD = $(CAIRO_LIBS)
 
 plugin_LTLIBRARIES += cairoblend.la
 cairoblend_la_SOURCES = mixer2/cairoblend/cairoblend.c
-cairoblend_la_CFLAGS = @CAIRO_CFLAGS@ @CFLAGS@
-cairoblend_la_LIBADD = @CAIRO_LIBS@
+cairoblend_la_CFLAGS = $(CAIRO_CFLAGS) $(CFLAGS)
+cairoblend_la_LIBADD = $(CAIRO_LIBS)
 
-ndvi_la_CPPFLAGS = @CAIRO_CFLAGS@ @CPPFLAGS@ -DHAVE_CAIRO
-ndvi_la_LIBADD = @CAIRO_LIBS@
+ndvi_la_CPPFLAGS = $(CAIRO_CFLAGS) $(CPPFLAGS) -DHAVE_CAIRO
+ndvi_la_LIBADD = $(CAIRO_LIBS)
 endif
 
 #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,50 +139,50 @@ plugin_LTLIBRARIES = \
 if HAVE_GAVL
 plugin_LTLIBRARIES += scale0tilt.la
 scale0tilt_la_SOURCES = filter/scale0tilt/scale0tilt.c
-scale0tilt_la_CFLAGS = $(GAVL_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
+scale0tilt_la_CFLAGS = $(GAVL_CFLAGS) $(AM_CFLAGS)
 scale0tilt_la_LIBADD = $(GAVL_LIBS)
 
 plugin_LTLIBRARIES += vectorscope.la
 vectorscope_la_SOURCES = filter/vectorscope/vectorscope.c filter/vectorscope/vectorscope_image.h
-vectorscope_la_CFLAGS = $(GAVL_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
+vectorscope_la_CFLAGS = $(GAVL_CFLAGS) $(AM_CFLAGS)
 vectorscope_la_LIBADD = $(GAVL_LIBS)
 
 plugin_LTLIBRARIES += rgbparade.la
 rgbparade_la_SOURCES = filter/rgbparade/rgbparade.c filter/rgbparade/rgbparade_image.h
-rgbparade_la_CFLAGS = $(GAVL_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
+rgbparade_la_CFLAGS = $(GAVL_CFLAGS) $(AM_CFLAGS)
 rgbparade_la_LIBADD = $(GAVL_LIBS)
 endif
 
 if HAVE_OPENCV
 plugin_LTLIBRARIES += facebl0r.la
 facebl0r_la_SOURCES = filter/facebl0r/facebl0r.cpp
-facebl0r_la_CXXFLAGS = $(OPENCV_CFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
+facebl0r_la_CXXFLAGS = $(OPENCV_CFLAGS) $(AM_CXXFLAGS)
 facebl0r_la_LIBADD = $(OPENCV_LIBS)
 plugin_LTLIBRARIES += facedetect.la
 facedetect_la_SOURCES = filter/facedetect/facedetect.cpp
-facedetect_la_CXXFLAGS = $(OPENCV_CFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
+facedetect_la_CXXFLAGS = $(OPENCV_CFLAGS) $(AM_CXXFLAGS)
 facedetect_la_LIBADD = $(OPENCV_LIBS)
 endif
 
 if HAVE_CAIRO
 plugin_LTLIBRARIES += cairogradient.la
 cairogradient_la_SOURCES = filter/cairogradient/cairogradient.c
-cairogradient_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
+cairogradient_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS)
 cairogradient_la_LIBADD = $(CAIRO_LIBS)
 
 plugin_LTLIBRARIES += cairoimagegrid.la
 cairoimagegrid_la_SOURCES = filter/cairoimagegrid/cairoimagegrid.c
-cairoimagegrid_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
+cairoimagegrid_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS)
 cairoimagegrid_la_LIBADD = $(CAIRO_LIBS)
 
 plugin_LTLIBRARIES += cairoaffineblend.la
 cairoaffineblend_la_SOURCES = mixer2/cairoaffineblend/cairoaffineblend.c
-cairoaffineblend_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
+cairoaffineblend_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS)
 cairoaffineblend_la_LIBADD = $(CAIRO_LIBS)
 
 plugin_LTLIBRARIES += cairoblend.la
 cairoblend_la_SOURCES = mixer2/cairoblend/cairoblend.c
-cairoblend_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
+cairoblend_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS)
 cairoblend_la_LIBADD = $(CAIRO_LIBS)
 
 ndvi_la_CXXFLAGS = $(CAIRO_CFLAGS) $(CXXFLAGS) -DHAVE_CAIRO

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,50 +139,50 @@ plugin_LTLIBRARIES = \
 if HAVE_GAVL
 plugin_LTLIBRARIES += scale0tilt.la
 scale0tilt_la_SOURCES = filter/scale0tilt/scale0tilt.c
-scale0tilt_la_CFLAGS = $(GAVL_CFLAGS) $(CFLAGS)
+scale0tilt_la_CFLAGS = $(GAVL_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
 scale0tilt_la_LIBADD = $(GAVL_LIBS)
 
 plugin_LTLIBRARIES += vectorscope.la
 vectorscope_la_SOURCES = filter/vectorscope/vectorscope.c filter/vectorscope/vectorscope_image.h
-vectorscope_la_CFLAGS = $(GAVL_CFLAGS) $(CFLAGS)
+vectorscope_la_CFLAGS = $(GAVL_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
 vectorscope_la_LIBADD = $(GAVL_LIBS)
 
 plugin_LTLIBRARIES += rgbparade.la
 rgbparade_la_SOURCES = filter/rgbparade/rgbparade.c filter/rgbparade/rgbparade_image.h
-rgbparade_la_CFLAGS = $(GAVL_CFLAGS) $(CFLAGS)
+rgbparade_la_CFLAGS = $(GAVL_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
 rgbparade_la_LIBADD = $(GAVL_LIBS)
 endif
 
 if HAVE_OPENCV
 plugin_LTLIBRARIES += facebl0r.la
 facebl0r_la_SOURCES = filter/facebl0r/facebl0r.cpp
-facebl0r_la_CFLAGS = $(OPENCV_CFLAGS) $(CFLAGS)
+facebl0r_la_CFLAGS = $(OPENCV_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
 facebl0r_la_LIBADD = $(OPENCV_LIBS)
 plugin_LTLIBRARIES += facedetect.la
 facedetect_la_SOURCES = filter/facedetect/facedetect.cpp
-facedetect_la_CFLAGS = $(OPENCV_CFLAGS) $(CFLAGS)
+facedetect_la_CFLAGS = $(OPENCV_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
 facedetect_la_LIBADD = $(OPENCV_LIBS)
 endif
 
 if HAVE_CAIRO
 plugin_LTLIBRARIES += cairogradient.la
 cairogradient_la_SOURCES = filter/cairogradient/cairogradient.c
-cairogradient_la_CFLAGS = $(CAIRO_CFLAGS) $(CFLAGS)
+cairogradient_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
 cairogradient_la_LIBADD = $(CAIRO_LIBS)
 
 plugin_LTLIBRARIES += cairoimagegrid.la
 cairoimagegrid_la_SOURCES = filter/cairoimagegrid/cairoimagegrid.c
-cairoimagegrid_la_CFLAGS = $(CAIRO_CFLAGS) $(CFLAGS)
+cairoimagegrid_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
 cairoimagegrid_la_LIBADD = $(CAIRO_LIBS)
 
 plugin_LTLIBRARIES += cairoaffineblend.la
 cairoaffineblend_la_SOURCES = mixer2/cairoaffineblend/cairoaffineblend.c
-cairoaffineblend_la_CFLAGS = $(CAIRO_CFLAGS) $(CFLAGS)
+cairoaffineblend_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
 cairoaffineblend_la_LIBADD = $(CAIRO_LIBS)
 
 plugin_LTLIBRARIES += cairoblend.la
 cairoblend_la_SOURCES = mixer2/cairoblend/cairoblend.c
-cairoblend_la_CFLAGS = $(CAIRO_CFLAGS) $(CFLAGS)
+cairoblend_la_CFLAGS = $(CAIRO_CFLAGS) $(AM_CFLAGS) $(CFLAGS)
 cairoblend_la_LIBADD = $(CAIRO_LIBS)
 
 ndvi_la_CPPFLAGS = $(CAIRO_CFLAGS) $(CPPFLAGS) -DHAVE_CAIRO


### PR DESCRIPTION
the autotools setup is in a sorry state, and seems to be not very well tested.

it wrongly uses `CFLAGS` (and `CPPFLAGS`) for C++-projects (`ndvi`, `facebl0r`, `facedetect`), resulting in
- unability to build out-of-tree
- not passing of crucial build-flags

afaict, there's also a misunderstanding of how `AM_*FLAGS` are supposed to work:
they are really used to define fallback-flags, if no per-target flags are specified. however, if you do specify per-target flags (as is the case for a couple of filters), the `AM_*FLAGS` will be ignored unless manually added.

~it seems that `autotools` is a 2nd-class citizen (as opposed to `cmake`), and is not tested with CI.
it's probably OK to only support a single build-system, but then we should just drop the unsupported build-systems completely...~

EDIT: sorry, I missed that `autotools` are indeed tested in `.travis.yml`; too well hidden behind docker :-)