### PR TITLE
using the void keyword in function declaration

### DIFF
--- a/include/frei0r.h
+++ b/include/frei0r.h
@@ -227,13 +227,13 @@
  * f0r_init() is called once when the plugin is loaded by the application.
  * \see f0r_deinit
  */
-int f0r_init();
+int f0r_init(void);
 
 /**
  * f0r_deinit is called once when the plugin is unloaded by the application.
  * \see f0r_init
  */
-void f0r_deinit();
+void f0r_deinit(void);
 
 //---------------------------------------------------------------------------
 


### PR DESCRIPTION
Using the void keyword in function declaration to fix the build
warning when enable frei0r in FFmpeg, the warning message like"
frei0r.h:230:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  230 | int f0r_init();
      | ^~~
CC	libavfilter/vf_gblur.o
frei0r.h:236:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  236 | void f0r_deinit();
      | ^~~~
"
Signed-off-by: Jun Zhao <barryjzhao@tencent.com>