### PR TITLE
Fix build warning in 64 bit Windows

### DIFF
--- a/include/frei0r.hpp
+++ b/include/frei0r.hpp
@@ -292,7 +292,7 @@ void f0r_get_plugin_info(f0r_plugin_info_t* info)
   info->major_version = frei0r::s_version.first; 
   info->minor_version = frei0r::s_version.second; 
   info->explanation = frei0r::s_explanation.c_str();
-  info->num_params =  frei0r::s_params.size(); 
+  info->num_params =  static_cast<int>(frei0r::s_params.size()); 
 }
 
 void f0r_get_param_info(f0r_param_info_t* info, int param_index)


### PR DESCRIPTION
64 bit windows builds issue a warning in frei0r.hpp:

`frei0r.hpp(295,46): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data`

Easy to fix and warnings in my builds irritate me so am submitting the world's most trivial PR!