### PR TITLE
Fill uninitialized gaps between grid images

### DIFF
--- a/src/filter/cairoimagegrid/cairoimagegrid.c
+++ b/src/filter/cairoimagegrid/cairoimagegrid.c
@@ -148,6 +148,13 @@ void draw_grid(cairo_imagegrid_instance_t* inst, unsigned char* dst, const unsig
   int pw = (int)(w/columns);
   int ph = (int)(h/rows);
 
+  if (w % pw != 0 || h % ph != 0) {
+    // Destination will have gaps - prefill with black.
+    cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 1.0);
+    cairo_rectangle (cr, 0, 0, w, h);
+    cairo_fill (cr);
+  }
+
   cairo_matrix_t   matrix;
   cairo_matrix_init_scale (&matrix, columns, rows);
   cairo_pattern_set_matrix (pattern, &matrix);


### PR DESCRIPTION
If the imagegrid images do not perfectly fill the destination buffer,
the dst image ends up with artifacts due to uninitialized memory.

As reported here:
https://forum.shotcut.org/t/artifacts-with-a-grid-filter-when-video-mode-and-original-video-aspect-ratios-dont-match-up/30688