### PR TITLE
Avoid destructing alpha channel.

### DIFF
--- a/src/filter/c0rners/c0rners.c
+++ b/src/filter/c0rners/c0rners.c
@@ -78,16 +78,15 @@ typedef struct		//premica v ravnini
 	float p;
 } premica2;
 
-//------------------------------------------------------
-//premica skozi dve tocki v ravnini (2D)
-//izracuna a,b,c za enacbo premice:   ax + by + c = 0
-//ps se sin a, cos a in p za normalno obliko
-//vrne: (return value)
-//-10	ce ni mozno dolociti p. (tocki sovpadata) coincident points
-//0	splosna p.			general case
-//+1	navpicna p.	x v *a		vertical
-//+2	vodoravna p.	y v *b		horizontal
-//a line through two points
+// line through two points in the plane (2D)
+// calculate a, b, c for the equation of the line: ax + by + c = 0
+// ps se sin a, cos a and p for normal form
+// return: (return value)
+// - 10 if it is not possible to determine p. coincident points
+// 0 general p. general case
+// + 1 vertical p. x v * a vertical
+// + 2 horizontal p. y v * b horizontal
+// a line through two points
 int premica2d(tocka2 t1, tocka2 t2, premica2 *p)
 {
 	float dx,dy,m;
@@ -131,10 +130,10 @@ int premica2d(tocka2 t1, tocka2 t2, premica2 *p)
 	return 0;
 }
 
-//-----------------------------------------------------
-//razdalja tocke od premice (za alpha feather)
-//distance between a point and a line
-//needed only for alpha feathering
+// ------------------------------------------------ -----
+// point distance from line (for alpha feather)
+// distance between a point and a line
+// needed only for alpha feathering
 float razd_t_p(tocka2 t, premica2 p)
 {
 	float r;
@@ -144,12 +143,12 @@ float razd_t_p(tocka2 t, premica2 p)
 	return r;
 }
 
-//-----------------------------------------------------
-//presecisce dveh premic v ravnini (2D)
-//vrne:
-//0  ce je vse OK
-//-1 ce sta premici vzporedni
-//intersection of two lines
+// ------------------------------------------------ -----
+// intersection of two lines in a plane (2D)
+// return:
+// 0 if everything is OK
+// - 1 if the lines are parallel
+// intersection of two lines
 int presecisce2(premica2 p1, premica2 p2, tocka2 *t)
 {
 	float d1,d2,d3;
@@ -166,13 +165,13 @@ int presecisce2(premica2 p1, premica2 p2, tocka2 *t)
 	return 0;
 }
 
-//---------------------------------------------------------------
-//generate mapping for a general quadrangle
-//wi,hi = input image size
-//wo,ho = output image size
-//vog[] = the four corners
-//str: 0=no stretch  1=do stretch
-//strx,stry:	stretch values   [0...1]   0.5 = no stretch
+// ------------------------------------------------ ---------------
+// generate mapping for a general quadrangle
+// wi, hi = input image size
+// wo, ho = output image size
+// vog [] = the four corners
+// str: 0 = no stretch 1 = do stretch
+// strx, stry: stretch values ​​[0 ... 1] 0.5 = no stretch
 void cetverokotnik4(int wi, int hi, int wo, int ho, tocka2 vog[], int str, float strx, float stry, float *map)
 {
 	double a,b,c,d,e,f,g,h,a2,b2,c2,u,v,aa,bb,de,sde,v1,v2,u1,u2;
@@ -477,14 +476,14 @@ void apply_alphamap(uint32_t* frame, int w, int h, unsigned char *amap, int oper
         }
 }
 
-//---------------------------------------------------------------
-//funkcija za byte polja (char)
-//generate map from the four corners
-//first checks for different types of degenerate geometrty...
-//wi,hi		input image size
-//wo,ho		output image size
-//vog[]		the four corners
-//nots[]		"inner" sides (for alpha feathering)
+// ------------------------------------------------ ---------------
+// function for byte fields (char)
+// generate map from the four corners
+// first checks for different types of degenerate geometrty ...
+// wi, hi input image size
+// wo, ho output image size
+// vog [] the four corners
+// nots [] "inner" sides (for alpha feathering)
 int geom4c_b(int wi, int hi, int wo, int ho, tocka2 vog[], int str, float strx, float stry, float *map, int nots[])
 {
 	premica2 p12,p23,p34,p41;

--- a/src/mixer2/cairoblend/cairoblend.c
+++ b/src/mixer2/cairoblend/cairoblend.c
@@ -175,7 +175,7 @@ void f0r_update2(f0r_instance_t instance, double time, const uint32_t* inframe1,
   unsigned char* out = (unsigned char*)outframe;
   int pixels = inst->width * inst->height;
 
-  frei0r_cairo_premultiply_rgba2 (dst, out, pixels, 0xff);
+  frei0r_cairo_premultiply_rgba2 (dst, out, pixels, -1);
   frei0r_cairo_premultiply_rgba (src, pixels, -1);
   draw_composite (inst, out, src, time);
   frei0r_cairo_unpremultiply_rgba (out, pixels);


### PR DESCRIPTION
Currently, the `f0r_update2` method destructs the alpha channel. The result is an opaque image.

I do not really know if this is the intended behaviour. But it causes some trouble in <a href="https://forum.shotcut.org/t/hello-can-the-mlt-file-that-will-be-imported-as-clip-have-transparent-background/20437/3">Shotcut</a>, because transparency is lost.

The current Shotcut solution was to not use clips with more then 1 track. When the clip has only one track, it does not call `cairoblend`'s `f0r_update2`, because there is no `transition`.

This patch fixes the issue.