### PR TITLE
fix(cairogradient): Fix artifacts/flashing when using cairogradient

### DIFF
--- a/src/filter/cairogradient/cairogradient.c
+++ b/src/filter/cairogradient/cairogradient.c
@@ -333,6 +333,9 @@ void f0r_update(f0r_instance_t instance, double time,
   unsigned char* src = (unsigned char*)inframe;
   int pixels = inst->width * inst->height;
 
+  // Clear the destination
+  memset(dst, 0, pixels * sizeof(uint32_t));
+
   frei0r_cairo_premultiply_rgba (src, pixels, -1);
   draw_gradient(inst, dst, src, time);
   frei0r_cairo_unpremultiply_rgba (dst, pixels);


### PR DESCRIPTION
Cairo blends with the destination image. This can result in artifacts if the destination image is not cleared.

As reported here:
https://forum.shotcut.org/t/size-position-rotate-and-nosync-works-on-sth-different-than-current-layer-plus-strange-blinking/37042