### PR TITLE
Make sure that CFLAGS from the cmdline are honoured

### DIFF
--- a/src/filter/levels/CMakeLists.txt
+++ b/src/filter/levels/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Set C99 flag for gcc
 if (CMAKE_COMPILER_IS_GNUCC)
-    set(CMAKE_C_FLAGS "-std=c99")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 endif (CMAKE_COMPILER_IS_GNUCC)
 
 set (SOURCES levels.c)

--- a/src/filter/three_point_balance/CMakeLists.txt
+++ b/src/filter/three_point_balance/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Set C99 flag for gcc
 if (CMAKE_COMPILER_IS_GNUCC)
-    set(CMAKE_C_FLAGS "-std=c99")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 endif (CMAKE_COMPILER_IS_GNUCC)
 
 set (SOURCES three_point_balance.c)


### PR DESCRIPTION
both the `levels` and the `three_point_balance` filters require C99, and therefore add `-std=c99` to the `CFLAGS`.

Unfortunately, they do so in a way that will ignore any CFLAGS set by the user (e.g. via envvars): https://github.com/dyne/frei0r/blob/9178c72e59112c40b6b45a54c03e47c245b80cdd/src/filter/levels/CMakeLists.txt#L3


a better way is of course to append the `-std=c99` to any pre-existing `CFLAGS`.
This is what this PR proposes.


background: in Debian, we set some additional hardening flags (totalling to `-D_FORTIFY_SOURCE=2 -g -O2 -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection`).
Currently our flags are simply ignored (and thus our QA bails out), with the attached patch, everything works as it should.