### PR TITLE
fix(cmake): Use CMAKE_CURRENT_SOURCE_DIR for robust subproject integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.12...3.31)
 
-list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 project (frei0r)
 set (VERSION 1.8)
@@ -29,13 +29,13 @@ if (NOT CMAKE_BUILD_TYPE)
 endif (NOT CMAKE_BUILD_TYPE)
 
 set (LIBDIR "${CMAKE_INSTALL_LIBDIR}/frei0r-1")
-set (FREI0R_DEF "${CMAKE_SOURCE_DIR}/msvc/frei0r_1_0.def")
-set (FREI0R_1_1_DEF "${CMAKE_SOURCE_DIR}/msvc/frei0r_1_1.def")
+set (FREI0R_DEF "${CMAKE_CURRENT_SOURCE_DIR}/msvc/frei0r_1_0.def")
+set (FREI0R_1_1_DEF "${CMAKE_CURRENT_SOURCE_DIR}/msvc/frei0r_1_1.def")
 
 # --- custom targets: ---
 INCLUDE( cmake/modules/TargetDistclean.cmake OPTIONAL)
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # For code documentation run: doxygen doc/Doxyfile
 # add_subdirectory (doc)

--- a/src/filter/mirr0r/mirr0r.cpp
+++ b/src/filter/mirr0r/mirr0r.cpp
@@ -20,8 +20,11 @@
 #include "frei0r.hpp"
 #include <cairo.h>
 #define _USE_MATH_DEFINES
+#ifdef _MSC_VER
+#include <math.h>
+#elif
 #include <cmath>
-
+#endif
 class Mirr0r : public frei0r::filter {
 
 private:

--- a/src/filter/mirr0r/mirr0r.cpp
+++ b/src/filter/mirr0r/mirr0r.cpp
@@ -22,7 +22,7 @@
 #define _USE_MATH_DEFINES
 #ifdef _MSC_VER
 #include <math.h>
-#elif
+#else
 #include <cmath>
 #endif
 class Mirr0r : public frei0r::filter {


### PR DESCRIPTION

---

This PR introduces two improvements: it fixes a compilation error on MSVC related to math constants and updates the CMake script for robust subproject integration.

### 1. Fix MSVC Compilation Error for Missing `M_PI`

A compilation failure on MSVC is resolved where math constants like `M_PI` were not found. This is because the standard `<cmath>` header on MSVC does not define them.

The fix involves defining the `_USE_MATH_DEFINES` macro and then including the C-style `<math.h>` header, which correctly exposes these constants when the macro is present. This change is wrapped in an `ifdef _MSC_VER` to ensure it only affects MSVC builds.

### 2. Improve CMake Subproject Integration

The `CMakeLists.txt` has been updated to use `CMAKE_CURRENT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR`.

**Reasoning:**

When `frei0r` is included as a subproject in a larger CMake build (e.g., via `FetchContent`), `CMAKE_SOURCE_DIR` incorrectly points to the top-level project's root. Using `CMAKE_CURRENT_SOURCE_DIR` ensures that all paths are resolved correctly relative to `frei0r`'s own source tree, making it a reliable CMake dependency.