### PR TITLE
update AUTHORS

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -51,4 +51,5 @@ Steinar H. Gunderson
 Thomas Coldrick
 Thomas Perl
 Till Theato
+Vadim Druzhin
 Vincent Pinon

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,4 +6,48 @@ Frei0r is a Dyne.org project maintained by Denis "Jaromil" Roio and Dan Dennedy.
 
 ## Developers who contributed, in alphabetic order:
 
-Akito Iwakura, Albert Frisch, Ajrat Makhmutov, Brendan Hack, Brian Matherly, Burkhard Plaum, Carlo E. Prelz, Christoph Willing, Erik Beck, Esmane, Filippo Giunchedi, Gabriel Finch (Salsaman), Georg Seidel, Henner Zeller, Hedde Bosman, IOhannes M. Zmölnig, Janne Liljeblad, Jean-Baptiste Mardelle, Jean-François Fortin Tam , Jean-Sebastien Senecal, Jerome Blanchi (d.j.a.y), Joshua M. Doe, Luca Bigliardi, Maksim Golovkin (Максим Головкин), Marko Cebokli, Martin Bayer, Mathieu Guindon, Matthias Schnoell, Nicolas Carion, Niels Elburg, Phillip Promesberger, Raphael Graf, Richard Spindler, Richard Ling (Chungzuwalla), Robert Schweikert, Ross Lagerwall, Samuel Mimram, Simon A. Eugster, Sofian Audry, Stefano Sabatini, Steinar H. Gunderson, Thomas Coldrick, Thomas Perl, Till Theato, Vincent Pinon.
+Akito Iwakura
+Albert Frisch
+Ajrat Makhmutov
+Brendan Hack
+Brian Matherly
+Burkhard Plaum
+Carlo E. Prelz
+Christoph Willing
+Erik Beck
+Esmane
+Filippo Giunchedi
+Gabriel Finch (Salsaman)
+Georg Seidel
+Henner Zeller
+Hedde Bosman
+IOhannes M. Zmölnig
+Janne Liljeblad
+Jean-Baptiste Mardelle
+Jean-François Fortin Tam 
+Jean-Sebastien Senecal
+Jerome Blanchi (d.j.a.y)
+Joshua M. Doe
+Luca Bigliardi
+Maksim Golovkin (Максим Головкин)
+Marko Cebokli
+Martin Bayer
+Mathieu Guindon
+Matthias Schnoell
+Nicolas Carion
+Niels Elburg
+Phillip Promesberger
+Raphael Graf
+Richard Spindler
+Richard Ling (Chungzuwalla)
+Robert Schweikert
+Ross Lagerwall
+Samuel Mimram
+Simon A. Eugster
+Sofian Audry
+Stefano Sabatini
+Steinar H. Gunderson
+Thomas Coldrick
+Thomas Perl
+Till Theato
+Vincent Pinon

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -27,6 +27,7 @@ Jean-Baptiste Mardelle
 Jean-François Fortin Tam 
 Jean-Sebastien Senecal
 Jerome Blanchi (d.j.a.y)
+Johann Jeg
 Joshua M. Doe
 Luca Bigliardi
 Maksim Golovkin (Максим Головкин)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -21,7 +21,7 @@ Gabriel Finch (Salsaman)
 Georg Seidel
 Henner Zeller
 Hedde Bosman
-IOhannes M. Zmölnig
+IOhannes m. zmölnig
 Janne Liljeblad
 Jean-Baptiste Mardelle
 Jean-François Fortin Tam 
@@ -33,7 +33,7 @@ Maksim Golovkin (Максим Головкин)
 Marko Cebokli
 Martin Bayer
 Mathieu Guindon
-Matthias Schnoell
+Matthias Schnöll
 Nicolas Carion
 Niels Elburg
 Phillip Promesberger


### PR DESCRIPTION
after all it wasn't as bad as i thought in #216...

this is how I understand the current AUTHORS file:
- it only contains humans (rather than institutions), ideally by their real name
- it only contains the AUTHORs of the frei0r-portion of the code (e.g. when porting a plugin from one framework to another, only the porter is mentioned (e.g. even though a number of plugins have been ported from https://github.com/fukuchi/EffecTV, @fukuchi is not in the list of authors).


with that in mind, my changeset is rather small:

- fixed spelling of a couple of names (mine ;-); also use umlaut for Matthias' name, as in hist source files)
- add @JohannJEG  ("mirr0r")
- add Vadim ("sleid0r")




- Closes: https://github.com/dyne/frei0r/issues/216
