### PR TITLE
README: Add packaging section and repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Stable frei0r releases are built automatically and made available on
 
 Frei0r sourcecode is released under the terms of the GNU General Public License and, eventually other compatible Free Software licenses.
 
+## Packaging
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/frei0r.svg?columns=3)](https://repology.org/project/frei0r/versions)
+
 ## Build dependencies 
 
 Frei0r can be built on GNU/Linux, M$/Windows and Apple/OSX platforms, possibly in even more environments like embedded devices.


### PR DESCRIPTION
Added packaging section and repology status badge to README to facilitate an efficient way to survey the status of frei0r across the package ecosystem.

Preview: https://github.com/luzpaz/frei0r/blob/repology/README.md#packaging

Note: the badge can also be put into a collapsible div:

## Packaging

<details><summary>Expand to view Repology badge</summary>

[![Packaging status](https://repology.org/badge/vertical-allrepos/frei0r.svg?columns=3)](https://repology.org/project/frei0r/versions)

</details>

## Build dependencies 

...