### PR TITLE
Fix bluescreen0r overwrites input alpha

### DIFF
--- a/src/filter/bluescreen0r/bluescreen0r.cpp
+++ b/src/filter/bluescreen0r/bluescreen0r.cpp
@@ -83,7 +83,7 @@ public:
 			*outpixel= (*pixel & 0x00FFFFFF); // copy all except alpha
 			
 			uint32_t d = distance(*pixel); // get distance
-			unsigned char a = 255; // default alpha
+			unsigned char a = (*pixel >> 24); // default alpha
 			if (d < distInt) {
 				a = 0;
 				if (d > distInt2) {
@@ -100,5 +100,8 @@ public:
 };
 
 
-frei0r::construct<bluescreen0r> plugin("bluescreen0r", "Color to alpha (blit SRCALPHA)", "Hedde Bosman",0,4,F0R_COLOR_MODEL_RGBA8888);
-
+frei0r::construct<bluescreen0r> plugin("bluescreen0r",
+									   "Color to alpha (blit SRCALPHA)",
+									   "Hedde Bosman",
+									   0, 5,
+									   F0R_COLOR_MODEL_RGBA8888);


### PR DESCRIPTION
Fixes https://github.com/mltframework/shotcut/issues/1745 and
https://forum.shotcut.org/t/chroma-key-turns-anything-not-behind-it-black/50087

In addition to the above cases where  MLT pads images whose aspect ratio of the greenscreen video with transparent black, consider also the case of an image with a shape against a transparent like this text example:

<img width="403" height="152" alt="image" src="https://github.com/user-attachments/assets/0ccad109-ee65-475a-b3be-60faf05b9510" />

With current bluescreen0r keyed on green:

<img width="403" height="152" alt="image" src="https://github.com/user-attachments/assets/7f086256-cea7-4550-8aa0-ce2aaca5a34e" />

With this change:

<img width="403" height="152" alt="image" src="https://github.com/user-attachments/assets/df567c75-ba5b-4530-9942-e77e4138b3e7" />
