### PR TITLE
Fix colorhalftone is not copying input alpha channel

### DIFF
--- a/src/filter/colorhalftone/colorhalftone.c
+++ b/src/filter/colorhalftone/colorhalftone.c
@@ -26,6 +26,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <math.h>
+#include <string.h>
 #include "frei0r.h"
 #include "frei0r/math.h"
 
@@ -73,6 +74,9 @@ void color_halftone(f0r_instance_t instance, double time,
 
   int width = inst->width;
   int height =  inst->height;
+
+  // Copy input to output to preserve alpha channel
+  memcpy(outframe, inframe, width * height * sizeof(uint32_t));
 
   double dotRadius = inst->dot_radius * 9.99;
   dotRadius = ceil(dotRadius);


### PR DESCRIPTION
The filter possibly assumes the host has initialized the output frame; however, that is not safe and incompatible with MLT. MLT does not assume it is safe to use the same buffer for input and output, and it does not add a often unncessary memcpy before calling the plugin's update function. Much more often than not, that memcpy would be unnecessary.