### PR TITLE
Fix curves crash (double free)

### DIFF
--- a/src/filter/curves/curves.c
+++ b/src/filter/curves/curves.c
@@ -573,11 +573,12 @@ int tokenise(char *string, const char *delimiter, char ***tokens)
     int count = 0;
     char *input = strdup(string);
     char *result = NULL;
-    result = strtok_r(string, delimiter, &input);
+	char *saveptr;
+    result = strtok_r(input, delimiter, &saveptr);
     while (result != NULL) {
         *tokens = realloc(*tokens, (count + 1) * sizeof(char *));
         (*tokens)[count++] = strdup(result);
-        result = strtok_r(NULL, delimiter, &input);
+        result = strtok_r(NULL, delimiter, &saveptr);
     }
     free(input);
     return count;


### PR DESCRIPTION
Since the change to strtok_r, we experience double free crashes  in Kdenlive, linked to line 583 of curves.c. From the documentation, strtok_r's last argument is an internally used char pointer to maintain context and not supposed to be the source string.