### PR TITLE
Fix crash regression in rgbsplit0r

### DIFF
--- a/src/filter/rgbsplit0r/rgbsplit0r.c
+++ b/src/filter/rgbsplit0r/rgbsplit0r.c
@@ -207,7 +207,9 @@ void f0r_update(f0r_instance_t instance, double time,
 
             // First make a blue layer shifted back
             if (((int)x >= (int)inst->shiftX) &&
-                ((int)y >= (int)inst->shiftY))
+                ((int)y >= (int)inst->shiftY) &&
+                ((x - inst->shiftX) < inst->width) &&
+                ((y - inst->shiftY) < inst->height))
             {
                 rgbsplit0r_extract_color((uint32_t *)(src +
                     (x - inst->shiftX) +


### PR DESCRIPTION
The change in this area in commit 69d0711 is causing a crash reported here: https://forum.shotcut.org/t/crash-using-the-rgb-shift-filter/51090

When it did not crash on my Linux dev system, it was producing blue garbage in the output. I suggest to add the conditions it had before as well.