### PR TITLE
fix(mirr0r): fix M_PI not defined on MSVC

### DIFF
--- a/src/filter/mirr0r/mirr0r.cpp
+++ b/src/filter/mirr0r/mirr0r.cpp
@@ -17,9 +17,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define _USE_MATH_DEFINES
 #include "frei0r.hpp"
 #include <cairo.h>
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 class Mirr0r : public frei0r::filter {


### PR DESCRIPTION
The _USE_MATH_DEFINES needs to be defined before all math header includes. In this case it means we have to put it on top to ensure it takes effect for all subsequent includes (eg. in cairo.h)