### PR TITLE
chore!: make dependency management explicite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,18 @@ option (WITHOUT_OPENCV "Disable plugins dependent upon OpenCV" OFF)
 option (WITHOUT_FACERECOGNITION "Disable facedetect plugin to avoid protobuf conflicts" OFF)
 
 if (NOT WITHOUT_OPENCV)
-  find_package (OpenCV)
+  find_package (OpenCV REQUIRED)
 endif ()
 
-find_package (Cairo)
+option (WITHOUT_CAIRO "Disable plugins dependent upon gavl" OFF)
+if (NOT WITHOUT_CAIRO)
+  find_package (Cairo REQUIRED)
+endif ()
 
 include(FindPkgConfig)
 option (WITHOUT_GAVL "Disable plugins dependent upon gavl" OFF)
 if (PKG_CONFIG_FOUND AND NOT WITHOUT_GAVL)
-  pkg_check_modules(GAVL gavl)
+  pkg_check_modules(GAVL REQUIRED gavl)
 endif ()
 
 include_directories (AFTER include)


### PR DESCRIPTION
Right now if `WITHOUT_XY` is `OFF`, but XY is not found, it behaves the same as if `WITHOUT_XY` was `ON`. This behavior ignores the user intent and makes it harder to get consistent and reproducible builds.

With this patch the user intent is honored:
- If `WITHOUT_XY` is `ON` frei0r will be build without filters depending on XY (same as before)
- If `WITOUT_XY` is `OFF` and XY is found, frei0r will be build with filters depending on XY (same as before)
- If `WITOUT_XY` is `OFF` and XY is not found, the build will fail in the CMake configure stage. The user has to either set `WITHOUT_XY=OFF` if they don't want the dependency or install it.

Also for Cairo there was no option to control whether it should be used yet. This patch introduces WITHOUT_CAIRO similar to the already existing WITHOUT_GAVL and WITHOUT_OPENCV