### PR TITLE
fix(msvc): put math.h after _USE_MATH_DEFINES again

### DIFF
--- a/src/filter/camerashake/camerashake.cpp
+++ b/src/filter/camerashake/camerashake.cpp
@@ -17,12 +17,12 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #if defined(_MSC_VER)
 #define _USE_MATH_DEFINES
 #endif
+#include <math.h>
 
 extern "C" {
     #include <frei0r.h>


### PR DESCRIPTION
The _USE_MATH_DEFINES is useless otherwise and MSVC does not know M_PI (error C2065: 'M_PI': undeclared identifier)