### PR TITLE
fix(ci): test release build with MSVC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,17 @@ jobs:
   #     - uses: actions/checkout@v6
   #     - uses: fsfe/reuse-action@v1
 
+  windows-build:
+    name: 🪟 win64 build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Build using nmake
+        run: |
+          cmake -S . -B build -G "NMake Makefiles" -D BUILD_TESTING=OFF -D WITHOUT_OPENCV=1 -D WITHOUT_CAIRO=1 -D WITHOUT_GAVL=1
+          cmake --build build
+
   c-lint:
     name: 🚨 C lint
     runs-on: ubuntu-latest

--- a/src/filter/colorenhance/colorenhance.c
+++ b/src/filter/colorenhance/colorenhance.c
@@ -157,7 +157,7 @@ void f0r_get_param_value(f0r_instance_t instance, f0r_param_t param, int param_i
     }
 }
 
-void f0r_update(f0r_instance_t instance, double, const uint32_t* inframe, uint32_t* outframe) 
+void f0r_update(f0r_instance_t instance, double time, const uint32_t* inframe, uint32_t* outframe)
 {
     colorenhance_t* inst = (colorenhance_t*)instance;
     const uint8_t* input = (const uint8_t*)inframe;


### PR DESCRIPTION
## Summary

- name the unused `time` parameter in `colorenhance` so MSVC accepts the function definition
- add a Windows NMake build to pull request CI using the same feature flags as the release build

## Root cause

The release workflow is the only workflow that builds on Windows with MSVC. PR CI currently builds only with Clang on Ubuntu, which accepts the unnamed parameter as an extension. MSVC rejects it with `C2055: expected formal parameter list, not a type list`.

The source correction was previously proposed in #281, which was closed as a duplicate. This PR includes that correction together with the CI coverage needed to catch similar release-only regressions before merge.

## Validation

- reproduced the failure locally with the NMake/MSVC release configuration
- rebuilt the `colorenhance` target successfully after the fix
- completed the full Windows release-equivalent build successfully
- ran `git diff --check`