### PR TITLE
chore: fix typo in cmake for WITHOUT_CAIRO 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if (NOT WITHOUT_OPENCV)
   find_package (OpenCV REQUIRED)
 endif ()
 
-option (WITHOUT_CAIRO "Disable plugins dependent upon gavl" OFF)
+option (WITHOUT_CAIRO "Disable plugins dependent upon Cairo" OFF)
 if (NOT WITHOUT_CAIRO)
   find_package (Cairo REQUIRED)
 endif ()


### PR DESCRIPTION
Fixes #254