### PR TITLE
fix(tint0r): build with SSE4 failing on incompatible types

### DIFF
--- a/src/filter/tint0r/tint0r.c
+++ b/src/filter/tint0r/tint0r.c
@@ -186,7 +186,8 @@ static void tint_sse41(const uint32_t* inframe, uint32_t* outframe, size_t len,
   tmp0 = _mm_mul_ps(cdelta, sse_amount),
   tmp1 = _mm_mul_ps(_mm_mul_ps(sse_amount, _mm_set1_ps(255.0)), cmin);
 
-  __m128 p, p0, p1, p2, p3, luma;
+  __m128i p;
+  __m128 p0, p1, p2, p3, luma;
 
   // Process pixels in groups of 4
   for (size_t i = 0; i < len; i++)
@@ -203,14 +204,20 @@ static void tint_sse41(const uint32_t* inframe, uint32_t* outframe, size_t len,
     #define tint(v) \
       luma = _mm_dp_ps((v), weights, 0x7F); \
       v = _mm_add_ps(_mm_mul_ps(comp_amount, (v)), \
-                     _mm_add_ps(_mm_mul_ps(luma, tmp0), tmp1)); \
-      v = _mm_cvtps_epi32(v)
+                     _mm_add_ps(_mm_mul_ps(luma, tmp0), tmp1));
 
     tint(p0); tint(p1); tint(p2); tint(p3);
 
+    /* Convert from float to int */
+    __m128i pi0, pi1, pi2, pi3;
+    pi0 = _mm_cvtps_epi32(p0);
+    pi1 = _mm_cvtps_epi32(p1);
+    pi2 = _mm_cvtps_epi32(p2);
+    pi3 = _mm_cvtps_epi32(p3);
+
     /* Gather the processed pixels */
-    p = _mm_packus_epi16(_mm_packus_epi32(p0, p1),
-                         _mm_packus_epi32(p2, p3));
+    p = _mm_packus_epi16(_mm_packus_epi32(pi0, pi1),
+                         _mm_packus_epi32(pi2, pi3));
 
     _mm_storeu_si128((__m128i*)(outframe + i * 4), p);
   }


### PR DESCRIPTION
Build with SSE4.1 is failing with GCC 14 on AlmaLinux 9 because of implicit conversion between float and int.

Here is the full error log:

```
[87/329] Building C object src/filter/tint0r/CMakeFiles/tint0r.dir/tint0r.c.o
FAILED: [code=1] src/filter/tint0r/CMakeFiles/tint0r.dir/tint0r.c.o
/opt/rh/gcc-toolset-14/root/usr/bin/gcc -Dtint0r_EXPORTS -I/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/include -isystem /builds/sysadmin/craft-ci/linux-64-gcc/include -O2 -g -DNDEBUG -fPIC -MD -MT src/filter/tint0r/CMakeFiles/tint0r.dir/tint0r.c.o -MF src/filter/tint0r/CMakeFiles/tint0r.dir/tint0r.c.o.d -o src/filter/tint0r/CMakeFiles/tint0r.dir/tint0r.c.o -c /builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c: In function ‘tint_sse41’:
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:195:9: error: incompatible types when assigning to type ‘__m128’ from type ‘__m128i’
195 |     p = _mm_loadu_si128((__m128i*)(inframe + i * 4));
|         ^~~~~~~~~~~~~~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:198:44: error: incompatible type for argument 1 of ‘_mm_cvtepu8_epi32’
198 |     p0 = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(p));
|                                            ^
|                                            |
|                                            __m128
In file included from /builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:27:
/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/smmintrin.h:521:28: note: expected ‘__m128i’ but argument is of type ‘__m128’
521 | _mm_cvtepu8_epi32 (__m128i __X)
|                    ~~~~~~~~^~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:199:59: error: incompatible type for argument 1 of ‘_mm_srli_si128’
199 |     p1 = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(_mm_srli_si128(p, 4)));
|                                                           ^
|                                                           |
|                                                           __m128
In file included from /opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/pmmintrin.h:31,
from /opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/tmmintrin.h:31,
from /opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/smmintrin.h:32:
/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/emmintrin.h:1227:25: note: expected ‘__m128i’ but argument is of type ‘__m128’
1227 | _mm_srli_si128 (__m128i __A, const int __N)
|                 ~~~~~~~~^~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:200:59: error: incompatible type for argument 1 of ‘_mm_srli_si128’
200 |     p2 = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(_mm_srli_si128(p, 8)));
|                                                           ^
|                                                           |
|                                                           __m128
/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/emmintrin.h:1227:25: note: expected ‘__m128i’ but argument is of type ‘__m128’
1227 | _mm_srli_si128 (__m128i __A, const int __N)
|                 ~~~~~~~~^~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:201:59: error: incompatible type for argument 1 of ‘_mm_srli_si128’
201 |     p3 = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(_mm_srli_si128(p, 12)));
|                                                           ^
|                                                           |
|                                                           __m128
/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/emmintrin.h:1227:25: note: expected ‘__m128i’ but argument is of type ‘__m128’
1227 | _mm_srli_si128 (__m128i __A, const int __N)
|                 ~~~~~~~~^~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:207:11: error: incompatible types when assigning to type ‘__m128’ from type ‘__m128i’
207 |       v = _mm_cvtps_epi32(v)
|           ^~~~~~~~~~~~~~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:209:5: note: in expansion of macro ‘tint’
209 |     tint(p0); tint(p1); tint(p2); tint(p3);
|     ^~~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:207:11: error: incompatible types when assigning to type ‘__m128’ from type ‘__m128i’
207 |       v = _mm_cvtps_epi32(v)
|           ^~~~~~~~~~~~~~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:209:15: note: in expansion of macro ‘tint’
209 |     tint(p0); tint(p1); tint(p2); tint(p3);
|               ^~~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:207:11: error: incompatible types when assigning to type ‘__m128’ from type ‘__m128i’
207 |       v = _mm_cvtps_epi32(v)
|           ^~~~~~~~~~~~~~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:209:25: note: in expansion of macro ‘tint’
209 |     tint(p0); tint(p1); tint(p2); tint(p3);
|                         ^~~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:207:11: error: incompatible types when assigning to type ‘__m128’ from type ‘__m128i’
207 |       v = _mm_cvtps_epi32(v)
|           ^~~~~~~~~~~~~~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:209:35: note: in expansion of macro ‘tint’
209 |     tint(p0); tint(p1); tint(p2); tint(p3);
|                                   ^~~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:212:43: error: incompatible type for argument 1 of ‘_mm_packus_epi32’
212 |     p = _mm_packus_epi16(_mm_packus_epi32(p0, p1),
|                                           ^~
|                                           |
|                                           __m128
/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/smmintrin.h:559:27: note: expected ‘__m128i’ but argument is of type ‘__m128’
559 | _mm_packus_epi32 (__m128i __X, __m128i __Y)
|                   ~~~~~~~~^~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:212:47: error: incompatible type for argument 2 of ‘_mm_packus_epi32’
212 |     p = _mm_packus_epi16(_mm_packus_epi32(p0, p1),
|                                               ^~
|                                               |
|                                               __m128
/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/smmintrin.h:559:40: note: expected ‘__m128i’ but argument is of type ‘__m128’
559 | _mm_packus_epi32 (__m128i __X, __m128i __Y)
|                                ~~~~~~~~^~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:213:43: error: incompatible type for argument 1 of ‘_mm_packus_epi32’
213 |                          _mm_packus_epi32(p2, p3));
|                                           ^~
|                                           |
|                                           __m128
/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/smmintrin.h:559:27: note: expected ‘__m128i’ but argument is of type ‘__m128’
559 | _mm_packus_epi32 (__m128i __X, __m128i __Y)
|                   ~~~~~~~~^~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:213:47: error: incompatible type for argument 2 of ‘_mm_packus_epi32’
213 |                          _mm_packus_epi32(p2, p3));
|                                               ^~
|                                               |
|                                               __m128
/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/smmintrin.h:559:40: note: expected ‘__m128i’ but argument is of type ‘__m128’
559 | _mm_packus_epi32 (__m128i __X, __m128i __Y)
|                                ~~~~~~~~^~~
/builds/sysadmin/craft-ci/downloads/git/libs/frei0r-plugins/src/filter/tint0r/tint0r.c:215:52: error: incompatible type for argument 2 of ‘_mm_storeu_si128’
215 |     _mm_storeu_si128((__m128i*)(outframe + i * 4), p);
|                                                    ^
|                                                    |
|                                                    __m128
/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/emmintrin.h:740:43: note: expected ‘__m128i’ but argument is of type ‘__m128’
740 | _mm_storeu_si128 (__m128i_u *__P, __m128i __B)
|                                   ~~~~~~~~^~~
[88/329] Building C object src/filter/three_point_balance/CMakeFiles/three_point_balance.dir/three_point_balance.c.o
```