### PR TITLE
fix(shake0scillate): include C++ math declarations

### DIFF
--- a/src/filter/shake0scillate/shake0scillate.cpp
+++ b/src/filter/shake0scillate/shake0scillate.cpp
@@ -20,7 +20,7 @@
 #include "frei0r.hpp"
 #include <cairo.h>
 #define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 
 class Shake0scillate : public frei0r::filter {
 


### PR DESCRIPTION
## Summary

- include the standard C++ `<cmath>` header
- make `std::sin` and `std::cos` declarations available on macOS/Apple Clang

## Verification

- built the `shake0scillate` target with GCC 14
- built the `shake0scillate` target with Clang 19
- `git diff --check`

Fixes #294